### PR TITLE
Fix deprecated use of TargetGuidByName method in Unity newer versions

### DIFF
--- a/Unity/Assets/NativeToolkit/Editor/PostProcessor.cs
+++ b/Unity/Assets/NativeToolkit/Editor/PostProcessor.cs
@@ -21,7 +21,11 @@ public class PostProcessor
         string file = File.ReadAllText(projPath);
         proj.ReadFromString(file);
 
-        string targetGuid = proj.TargetGuidByName("Unity-iPhone");
+#if UNITY_2019_3_OR_NEWER
+        string targetGuid = proj.GetUnityFrameworkTargetGuid();
+#else
+        string targetGuid = proj.TargetGuidByName(PBXProject.GetUnityTargetName());
+#endif
 
         proj.SetBuildProperty(targetGuid, "CLANG_ENABLE_MODULES", "YES");
         proj.SetBuildProperty(targetGuid, "ENABLE_BITCODE", "NO");


### PR DESCRIPTION
In Unity 2019.3 or newer, the TargetGuidByName is deprecated.